### PR TITLE
Add basic server data frontend

### DIFF
--- a/CSI_UI/src/components/Server/ServerDetails.css
+++ b/CSI_UI/src/components/Server/ServerDetails.css
@@ -1,0 +1,3 @@
+.server-details-container {
+  margin-top: 1rem;
+}

--- a/CSI_UI/src/components/Server/ServerDetails.tsx
+++ b/CSI_UI/src/components/Server/ServerDetails.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { RuxContainer, RuxTable, RuxTableHeader, RuxTableHeaderRow, RuxTableHeaderCell, RuxTableBody, RuxTableRow, RuxTableCell } from "@astrouxds/react";
+import { ServerData } from "../../services/ServerService";
+import "./ServerDetails.css";
+
+interface Props {
+  server: ServerData;
+}
+
+const ServerDetails: React.FC<Props> = ({ server }) => {
+  const cpus = server.sensors?.cpus ? Object.values(server.sensors.cpus) : [];
+  const ram = server.sensors?.ram;
+
+  return (
+    <RuxContainer className="server-details-container">
+      <div slot="header">Server Details</div>
+      <p>IP: {server.device?.comms?.ip}</p>
+      {ram && (
+        <p>RAM Utilization: {ram.utilization_percent}%</p>
+      )}
+      {cpus.length > 0 && (
+        <RuxTable>
+          <RuxTableHeader>
+            <RuxTableHeaderRow>
+              <RuxTableHeaderCell>CPU</RuxTableHeaderCell>
+              <RuxTableHeaderCell>Utilization %</RuxTableHeaderCell>
+            </RuxTableHeaderRow>
+          </RuxTableHeader>
+          <RuxTableBody>
+            {cpus.map((cpu, idx) => (
+              <RuxTableRow key={idx}>
+                <RuxTableCell>{cpu.unique_id || idx}</RuxTableCell>
+                <RuxTableCell>{cpu.utilization_percent}</RuxTableCell>
+              </RuxTableRow>
+            ))}
+          </RuxTableBody>
+        </RuxTable>
+      )}
+    </RuxContainer>
+  );
+};
+
+export default ServerDetails;

--- a/CSI_UI/src/components/SiteEndpointLayout/MainContentDisplay.tsx
+++ b/CSI_UI/src/components/SiteEndpointLayout/MainContentDisplay.tsx
@@ -12,6 +12,8 @@ import {
 import PlugContainer, { Outlet } from "../PDU/PlugContainer";
 import LoadHistoryChart from "./LoadHistoryChart";
 import { fetchDeviceMetrics } from "../../services/DeviceService";
+import { fetchServerData, ServerData } from "../../services/ServerService";
+import ServerDetails from "../Server/ServerDetails";
 import "./MainContentDisplay.css";
 
 interface MainContentDisplayProps {
@@ -47,6 +49,7 @@ const MainContentDisplay: React.FC<MainContentDisplayProps> = ({
   const [ampsData, setAmpsData] = useState<{ x: string; y: number }[]>(
     initialAmpsData || []
   );
+  const [serverData, setServerData] = useState<ServerData | null>(null);
 
   useEffect(() => {
     if (selectedDevice) {
@@ -61,6 +64,19 @@ const MainContentDisplay: React.FC<MainContentDisplayProps> = ({
         setWattsData(wattsData);
         setAmpsData(ampsData);
       });
+    }
+  }, [selectedDevice]);
+
+  useEffect(() => {
+    if (selectedDevice && selectedDevice.type === "Server") {
+      fetchServerData()
+        .then((data) => setServerData(data))
+        .catch((err) => {
+          console.error("Failed to fetch server data", err);
+          setServerData(null);
+        });
+    } else {
+      setServerData(null);
     }
   }, [selectedDevice]);
 
@@ -125,7 +141,6 @@ const MainContentDisplay: React.FC<MainContentDisplayProps> = ({
               <LoadHistoryChart
                 wattsData={wattsData}
                 ampsData={ampsData}
-                title="PDU Load History"
               />
             </div>
           );
@@ -137,20 +152,8 @@ const MainContentDisplay: React.FC<MainContentDisplayProps> = ({
           );
         }
       case "Server":
-        if (typeof serverData !== "undefined" && serverData) {
-          return (
-            <div className="server-details">
-              <h4>Server Details:</h4>
-              <p>
-                Server Name: {selectedDevice.name} <br />
-                Status: {selectedDevice.status}
-              </p>
-              <LoadHistoryChart
-                data={serverData.loadHistory}
-                title="Server Load History"
-              />
-            </div>
-          );
+        if (serverData) {
+          return <ServerDetails server={serverData} />;
         }
       // fall through to default if no serverData
       default:

--- a/CSI_UI/src/services/ServerService.ts
+++ b/CSI_UI/src/services/ServerService.ts
@@ -1,0 +1,28 @@
+import axios from "axios";
+
+const BASE_API_URL = `${import.meta.env.VITE_BASE_URL}`;
+
+export interface ServerData {
+  device?: {
+    label?: string;
+    comms?: {
+      ip?: string;
+    };
+    make?: string;
+  };
+  sensors?: {
+    cpus?: Record<string, { utilization_percent?: number }>;
+    drives?: Record<string, { utilization_percent?: number }>;
+    ram?: {
+      utilization_percent?: string;
+      total_bytes?: string;
+      cached_bytes?: string;
+    };
+  };
+  parameters?: Record<string, unknown>;
+}
+
+export async function fetchServerData(): Promise<ServerData> {
+  const resp = await axios.get<ServerData>(`${BASE_API_URL}/mock/server`);
+  return resp.data;
+}

--- a/CSI_UI/src/services/index.ts
+++ b/CSI_UI/src/services/index.ts
@@ -1,3 +1,4 @@
 export * from "./PDUservice";
 export * from "./SiteService";
 export * from "./DeviceService";
+export * from "./ServerService";


### PR DESCRIPTION
## Summary
- implement service to fetch mock server JSON
- add new ServerDetails component
- expose server service from services index
- load server data in MainContentDisplay and render with new component

## Testing
- `npm run build` *(fails: cannot find modules)*
- `npm run lint` *(fails: cannot find modules)*
