### PR TITLE
Add server chart view with toggle

### DIFF
--- a/CSI_UI/src/components/Server/Charts/CPULineChart.tsx
+++ b/CSI_UI/src/components/Server/Charts/CPULineChart.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import GenericLineChart from "../../common/GenericLineChart/GenericLineChart";
+import { ServerData } from "../../../services/ServerService";
+
+interface CPULineChartProps {
+  server: ServerData;
+}
+
+const CPULineChart: React.FC<CPULineChartProps> = ({ server }) => {
+  const cpus = server.sensors?.cpus
+    ? Object.values(server.sensors.cpus)
+    : [];
+
+  const cpuData = [
+    {
+      id: "CPU Usage",
+      data: cpus.map((cpu, idx) => ({
+        x: cpu.id || idx,
+        y: (cpu.utilization_percent ?? 0) * 100,
+      })),
+    },
+  ];
+
+  if (cpuData[0].data.length === 0) {
+    return <p>No CPU data available</p>;
+  }
+
+  return (
+    <GenericLineChart
+      data={cpuData}
+      xScaleType="point"
+      axisBottomLegend="CPU"
+      axisLeftLegend="Utilization %"
+      height="250px"
+      width="100%"
+      colors={["#00A3E0"]}
+    />
+  );
+};
+
+export default CPULineChart;
+

--- a/CSI_UI/src/components/Server/Charts/GPULineChart.tsx
+++ b/CSI_UI/src/components/Server/Charts/GPULineChart.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import GenericLineChart from "../../common/GenericLineChart/GenericLineChart";
+import { ServerData } from "../../../services/ServerService";
+
+interface GPULineChartProps {
+  server: ServerData;
+}
+
+const GPULineChart: React.FC<GPULineChartProps> = ({ server }) => {
+  const gpus = server.sensors?.gpus
+    ? Object.values(server.sensors.gpus)
+    : [];
+
+  const gpuData = [
+    {
+      id: "GPU Usage",
+      data: gpus.map((gpu, idx) => ({
+        x: gpu.id || idx,
+        y: (gpu.utilization_percent ?? 0) * 100,
+      })),
+    },
+  ];
+
+  if (gpuData[0].data.length === 0) {
+    return <p>No GPU data available</p>;
+  }
+
+  return (
+    <GenericLineChart
+      data={gpuData}
+      xScaleType="point"
+      axisBottomLegend="GPU"
+      axisLeftLegend="Utilization %"
+      height="250px"
+      width="100%"
+      colors={["#FF6F20"]}
+    />
+  );
+};
+
+export default GPULineChart;
+

--- a/CSI_UI/src/components/Server/Charts/GPURamLineChart.tsx
+++ b/CSI_UI/src/components/Server/Charts/GPURamLineChart.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import GenericLineChart from "../../common/GenericLineChart/GenericLineChart";
+import { ServerData } from "../../../services/ServerService";
+
+interface GPURamLineChartProps {
+  server: ServerData;
+}
+
+const GPURamLineChart: React.FC<GPURamLineChartProps> = ({ server }) => {
+  const gpus = server.sensors?.gpus
+    ? Object.values(server.sensors.gpus)
+    : [];
+
+  const gpuRamData = [
+    {
+      id: "GPU RAM Utilization",
+      data: gpus.map((gpu, idx) => {
+        const total = gpu.memory_total_bytes ?? 0;
+        const used = gpu.memory_used_bytes ?? 0;
+        const percent = total > 0 ? (used / total) * 100 : 0;
+        return { x: gpu.id || idx, y: percent };
+      }),
+    },
+  ];
+
+  if (gpuRamData[0].data.length === 0) {
+    return <p>No GPU RAM data available</p>;
+  }
+
+  return (
+    <GenericLineChart
+      data={gpuRamData}
+      xScaleType="point"
+      axisBottomLegend="GPU"
+      axisLeftLegend="RAM Usage %"
+      height="250px"
+      width="100%"
+      colors={["#00c7cb"]}
+    />
+  );
+};
+
+export default GPURamLineChart;
+

--- a/CSI_UI/src/components/Server/Charts/RamLineChart.tsx
+++ b/CSI_UI/src/components/Server/Charts/RamLineChart.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import GenericLineChart from "../../common/GenericLineChart/GenericLineChart";
+import { ServerData } from "../../../services/ServerService";
+
+interface RamLineChartProps {
+  server: ServerData;
+}
+
+const RamLineChart: React.FC<RamLineChartProps> = ({ server }) => {
+  const ramUtil = parseFloat(server.sensors?.ram?.utilization_percent || "0");
+
+  const ramData = [
+    {
+      id: "RAM Utilization",
+      data: [{ x: "RAM", y: ramUtil }],
+    },
+  ];
+
+  if (isNaN(ramUtil)) {
+    return <p>No RAM data available</p>;
+  }
+
+  return (
+    <GenericLineChart
+      data={ramData}
+      xScaleType="point"
+      axisBottomLegend="RAM"
+      axisLeftLegend="Utilization %"
+      height="250px"
+      width="100%"
+      colors={["#938bdb"]}
+    />
+  );
+};
+
+export default RamLineChart;
+

--- a/CSI_UI/src/components/Server/Charts/TempratureLineChart.tsx
+++ b/CSI_UI/src/components/Server/Charts/TempratureLineChart.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import GenericLineChart from "../../common/GenericLineChart/GenericLineChart";
+import { ServerData } from "../../../services/ServerService";
+
+interface TemperatureLineChartProps {
+  server: ServerData;
+}
+
+const TemperatureLineChart: React.FC<TemperatureLineChartProps> = ({ server }) => {
+  const cpus = server.sensors?.cpus
+    ? Object.values(server.sensors.cpus)
+    : [];
+  const gpus = server.sensors?.gpus
+    ? Object.values(server.sensors.gpus)
+    : [];
+
+  const cpuTempData = cpus.map((cpu, idx) => ({
+    x: cpu.id || idx,
+    y: cpu.temperature_c ?? 0,
+  }));
+
+  const gpuTempData = gpus.map((gpu, idx) => ({
+    x: gpu.id || idx,
+    y: gpu.temperature_c ?? 0,
+  }));
+
+  const chartData = [
+    { id: "CPU Temp", data: cpuTempData },
+    ...(gpuTempData.length > 0 ? [{ id: "GPU Temp", data: gpuTempData }] : []),
+  ];
+
+  if (chartData.every((d) => d.data.length === 0)) {
+    return <p>No temperature data available</p>;
+  }
+
+  return (
+    <GenericLineChart
+      data={chartData}
+      xScaleType="point"
+      axisBottomLegend="Component"
+      axisLeftLegend="Temp °C"
+      height="250px"
+      width="100%"
+      colors={["#00A3E0", "#FF6F20"]}
+    />
+  );
+};
+
+export default TemperatureLineChart;
+

--- a/CSI_UI/src/components/Server/ServerDetails.css
+++ b/CSI_UI/src/components/Server/ServerDetails.css
@@ -1,3 +1,9 @@
 .server-details-container {
   margin-top: 1rem;
 }
+
+.view-toggle {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}

--- a/CSI_UI/src/components/Server/ServerDetails.tsx
+++ b/CSI_UI/src/components/Server/ServerDetails.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import {
   RuxTable,
   RuxTableHeader,
@@ -13,6 +13,11 @@ import {
   RuxAccordionItem,
 } from "@astrouxds/react";
 import { ServerData } from "../../services/ServerService";
+import CPULineChart from "./Charts/CPULineChart";
+import GPULineChart from "./Charts/GPULineChart";
+import GPURamLineChart from "./Charts/GPURamLineChart";
+import RamLineChart from "./Charts/RamLineChart";
+import TemperatureLineChart from "./Charts/TempratureLineChart";
 import {
   formatBandwidth,
   formatSpeed,
@@ -25,6 +30,7 @@ interface Props {
 }
 
 const ServerDetails: React.FC<Props> = ({ server }) => {
+  const [view, setView] = useState<'table' | 'chart'>('table');
   const cpus = server.sensors?.cpus ? Object.values(server.sensors.cpus) : [];
   const nics = server.sensors?.nics ? Object.values(server.sensors.nics) : [];
   const ram = server.sensors?.ram;
@@ -47,10 +53,17 @@ const ServerDetails: React.FC<Props> = ({ server }) => {
               icon="list"
               className="view-toggle-button"
               aria-label="List View"
+              secondary={view !== 'table'}
+              onClick={() => setView('table')}
             ></RuxButton>
-            <RuxButton size="small" icon="show-chart"></RuxButton>
+            <RuxButton
+              size="small"
+              icon="show-chart"
+              secondary={view !== 'chart'}
+              onClick={() => setView('chart')}
+            ></RuxButton>
           </div>
-          {cpus.length > 0 && (
+          {view === 'table' && cpus.length > 0 && (
             <RuxTable>
               <RuxTableHeader>
                 <RuxTableHeaderRow>
@@ -78,7 +91,18 @@ const ServerDetails: React.FC<Props> = ({ server }) => {
               </RuxTableBody>
             </RuxTable>
           )}
-          {ram && <p>RAM Utilization: {ram.utilization_percent}%</p>}
+          {view === 'chart' && (
+            <>
+              <CPULineChart server={server} />
+              <GPULineChart server={server} />
+              <GPURamLineChart server={server} />
+              <RamLineChart server={server} />
+              <TemperatureLineChart server={server} />
+            </>
+          )}
+          {view === 'table' && ram && (
+            <p>RAM Utilization: {ram.utilization_percent}%</p>
+          )}
         </RuxAccordionItem>
         <RuxAccordionItem>
           <div slot="prefix">

--- a/CSI_UI/src/services/ServerService.ts
+++ b/CSI_UI/src/services/ServerService.ts
@@ -21,6 +21,16 @@ export interface ServerData {
         temperature_c?: number;
       }
     >;
+    gpus?: Record<
+      string,
+      {
+        id?: string;
+        utilization_percent?: number;
+        memory_total_bytes?: number;
+        memory_used_bytes?: number;
+        temperature_c?: number;
+      }
+    >;
     drives?: Record<string, { utilization_percent?: number }>;
     ram?: {
       utilization_percent?: string;


### PR DESCRIPTION
## Summary
- implement line charts for server CPU, GPU, GPU RAM, RAM and temperature using GenericLineChart
- extend server data interface with GPU info
- add chart/table toggle in `ServerDetails`
- style toggle area

