### PR TITLE
Add confirmation and options for PDU plugs

### DIFF
--- a/CSI_UI/src/components/PDU/PlugContainer.css
+++ b/CSI_UI/src/components/PDU/PlugContainer.css
@@ -20,6 +20,12 @@
     align-items: center;
     gap: 5px;
     cursor: pointer; /* Indicate clickable element */
+    padding: 4px;
+    border-radius: 4px;
+}
+
+.plug-item:hover {
+    outline: 1px dashed var(--color-background-surface-hover, #888);
 }
 
 .plug-label {

--- a/CSI_UI/src/components/PDU/PlugContainer.tsx
+++ b/CSI_UI/src/components/PDU/PlugContainer.tsx
@@ -1,5 +1,11 @@
 import React from "react";
-import { RuxMonitoringIcon } from "@astrouxds/react";
+import {
+  RuxMonitoringIcon,
+  RuxPopUp,
+  RuxMenu,
+  RuxMenuItem,
+} from "@astrouxds/react";
+import { OutletAction } from "../../services/PDUservice";
 import "./PlugContainer.css";
 
 export interface Outlet {
@@ -10,12 +16,12 @@ export interface Outlet {
 
 interface PlugContainerProps {
   outlets: Record<string, Outlet>;
-  onToggleOutlet: (outletId: string, currentState: string | undefined) => void;
+  onOutletAction: (outletId: string, action: OutletAction) => void;
 }
 
 const PlugContainer: React.FC<PlugContainerProps> = ({
   outlets = {},
-  onToggleOutlet,
+  onOutletAction,
 }) => {
   const getIconStatus = (
     outletState: string | undefined
@@ -71,13 +77,41 @@ const PlugContainer: React.FC<PlugContainerProps> = ({
       <div className="plug-row">
         {Object.entries(outlets).map(([outletId, outletData]) => (
           <div key={outletId} className="plug-item">
-            <RuxMonitoringIcon
-              status={getIconStatus(outletData.state)}
-              icon="power"
-              label={outletData.name || `Outlet ${outletId}`}
-              onClick={() => onToggleOutlet(outletId, outletData.state)}
-              title={`Toggle ${outletData.name || `Outlet ${outletId}`}`}
-            />
+            <RuxPopUp placement="bottom" closeOnSelect>
+              <RuxMonitoringIcon
+                status={getIconStatus(outletData.state)}
+                icon="power"
+                label={outletData.name || `Outlet ${outletId}`}
+                slot="trigger"
+                title={`Control ${outletData.name || `Outlet ${outletId}`}`}
+              />
+              <RuxMenu
+                onRuxmenuselected={(e) => {
+                  const val = e.detail.value as string;
+                  let action: OutletAction | null = null;
+                  if (val === "on") action = "POWER_ON";
+                  else if (val === "off") action = "POWER_OFF";
+                  else if (val === "reboot") action = "REBOOT";
+                  if (action) {
+                    if (
+                      action === "POWER_OFF" &&
+                      !window.confirm(
+                        `Are you sure you want to power off ${
+                          outletData.name || `Outlet ${outletId}`
+                        }?`
+                      )
+                    ) {
+                      return;
+                    }
+                    onOutletAction(outletId, action);
+                  }
+                }}
+              >
+                <RuxMenuItem value="on">Power On</RuxMenuItem>
+                <RuxMenuItem value="off">Power Off</RuxMenuItem>
+                <RuxMenuItem value="reboot">Reboot</RuxMenuItem>
+              </RuxMenu>
+            </RuxPopUp>
             <span className="plug-label">
               {getStatusLabel(outletData.state)}
             </span>

--- a/CSI_UI/src/components/SiteEndpointLayout/MainContentDisplay.tsx
+++ b/CSI_UI/src/components/SiteEndpointLayout/MainContentDisplay.tsx
@@ -4,7 +4,7 @@ import {
   RuxButton,
   RuxIndeterminateProgress,
 } from "@astrouxds/react";
-import { PDUData } from "../../services/PDUservice";
+import { PDUData, OutletAction } from "../../services/PDUservice";
 import {
   SiteWithOptionalDevices,
   DeviceResponse as IDeviceResponse,
@@ -22,7 +22,7 @@ interface MainContentDisplayProps {
   selectedDevice?: IDeviceResponse | null;
   pduData: PDUData | null;
   statuses: string[];
-  handleTogglePower: (outletIndex: number) => void;
+  handleOutletAction: (outletIndex: number, action: OutletAction) => void;
   setShowAddDeviceForm: (show: boolean) => void;
   isDeviceFormVisible: boolean;
   isLoadingDevices?: boolean;
@@ -36,7 +36,7 @@ const MainContentDisplay: React.FC<MainContentDisplayProps> = ({
   selectedDevice,
   pduData,
   statuses,
-  handleTogglePower,
+  handleOutletAction,
   setShowAddDeviceForm,
   isDeviceFormVisible,
   isLoadingDevices,
@@ -124,15 +124,15 @@ const MainContentDisplay: React.FC<MainContentDisplayProps> = ({
     {}
   );
 
-  const handleOutletToggleWrapper = (
+  const handleOutletActionWrapper = (
     outletId: string,
-    currentState: string | undefined
+    action: OutletAction
   ) => {
     const outletIndex = parseInt(outletId, 10) - 1;
     if (!isNaN(outletIndex) && outletIndex >= 0) {
-      handleTogglePower(outletIndex);
+      handleOutletAction(outletIndex, action);
     } else {
-      console.error("Invalid outletId passed to toggle handler:", outletId);
+      console.error("Invalid outletId passed to action handler:", outletId);
     }
   };
 
@@ -146,7 +146,7 @@ const MainContentDisplay: React.FC<MainContentDisplayProps> = ({
             <div className="pdu-container">
               <PlugContainer
                 outlets={outletsForPlugContainer}
-                onToggleOutlet={handleOutletToggleWrapper}
+                onOutletAction={handleOutletActionWrapper}
               />
               <LoadHistoryChart
                 wattsData={wattsData}

--- a/CSI_UI/src/components/SiteEndpointLayout/SiteEndpointLayout.tsx
+++ b/CSI_UI/src/components/SiteEndpointLayout/SiteEndpointLayout.tsx
@@ -12,7 +12,11 @@ import {
   SiteWithOptionalDevices,
   SiteCreateData,
 } from "../../services/SiteService";
-import { PDUData, toggleOutletPower } from "../../services/PDUservice";
+import {
+  PDUData,
+  toggleOutletPower,
+  OutletAction,
+} from "../../services/PDUservice";
 import { Device } from "../../services/DeviceService";
 import "./SiteEndpointLayout.css";
 import { RuxContainer, RuxButton } from "@astrouxds/react";
@@ -319,7 +323,10 @@ const SiteEndpointLayout: React.FC = () => {
   const selectedDeviceObject =
     selectedSiteObject?.devices?.[selectedDevIdx] || null;
 
-  const handleTogglePower = async (outletIndex: number) => {
+  const handleOutletAction = async (
+    outletIndex: number,
+    action: OutletAction
+  ) => {
     if (
       !selectedSiteObject ||
       !selectedDeviceObject ||
@@ -341,9 +348,6 @@ const SiteEndpointLayout: React.FC = () => {
       return;
     }
 
-    const currentStatus = currentOutlet.state;
-    const newStatus = currentStatus === "POWER_ON" ? "POWER_OFF" : "POWER_ON";
-
     const deviceArg: Device = {
       id: selectedDeviceObject.deviceId,
       name: selectedDeviceObject.name,
@@ -357,9 +361,9 @@ const SiteEndpointLayout: React.FC = () => {
     };
 
     try {
-      await toggleOutletPower(deviceArg, outletKey, newStatus);
+      await toggleOutletPower(deviceArg, outletKey, action);
 
-      await refreshSelectedDeviceData(500);
+      await refreshSelectedDeviceData(action === "REBOOT" ? 1000 : 500);
     } catch (error) {
       console.error("Failed to toggle power:", error);
       await refreshSelectedDeviceData();
@@ -461,7 +465,7 @@ const SiteEndpointLayout: React.FC = () => {
           selectedDevice={selectedDeviceObject}
           pduData={pduData}
           statuses={statuses}
-          handleTogglePower={handleTogglePower}
+          handleOutletAction={handleOutletAction}
           setShowAddDeviceForm={toggleAddDeviceForm}
           isDeviceFormVisible={showAddDeviceForm}
           isLoadingDevices={isLoadingDevices}

--- a/CSI_UI/src/services/PDUservice.ts
+++ b/CSI_UI/src/services/PDUservice.ts
@@ -32,10 +32,12 @@ export const fetchPDUData = async (): Promise<PDUData[]> => {
   return response.data;
 };
 
+export type OutletAction = "POWER_ON" | "POWER_OFF" | "REBOOT";
+
 export const toggleOutletPower = async (
   device: Device,
   outletId: number | string,
-  powerState: "POWER_ON" | "POWER_OFF"
+  powerState: OutletAction
 ): Promise<PduCommandResponseItem[]> => {
   if (device.type !== PDU_DEVICE_TYPE_IDENTIFIER) {
     const errorMessage = `Device '${device.name}' (type: ${device.type}) is not a recognized PDU device. Cannot toggle outlet power. Expected type '${PDU_DEVICE_TYPE_IDENTIFIER}'.`;


### PR DESCRIPTION
## Summary
- enhance PlugContainer with popup menu for power on/off/reboot
- add OutletAction type and allow PDUservice to send reboot commands
- wire new outlet action handler through MainContentDisplay and SiteEndpointLayout
- highlight plug items as clickable elements
