### PR TITLE
Replace CPU line chart with per-core metrics

### DIFF
--- a/CSI_UI/src/components/Server/Charts/CPUPerCoreGrid.tsx
+++ b/CSI_UI/src/components/Server/Charts/CPUPerCoreGrid.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import MetricCard from "../MetricCard";
+import { ServerData } from "../../../services/ServerService";
+
+interface CPUPerCoreGridProps {
+  server: ServerData;
+}
+
+const CPUPerCoreGrid: React.FC<CPUPerCoreGridProps> = ({ server }) => {
+  const cpus = server.sensors?.cpus ? Object.values(server.sensors.cpus) : [];
+
+  if (cpus.length === 0) {
+    return <p>No CPU data available</p>;
+  }
+
+  return (
+    <div className="metric-cards-container">
+      {cpus.map((cpu, idx) => (
+        <MetricCard
+          key={idx}
+          title={`CPU ${cpu.id || idx}`}
+          value={`${(cpu.utilization_percent ?? 0).toFixed(1)}`}
+          unit="%"
+          data={[cpu.utilization_percent ?? 0]}
+          thresholds={{
+            normal: 0,
+            caution: 70,
+            serious: 85,
+            critical: 95,
+          }}
+          icon="processor"
+        />
+      ))}
+    </div>
+  );
+};
+
+export default CPUPerCoreGrid;

--- a/CSI_UI/src/components/Server/ServerDetails.tsx
+++ b/CSI_UI/src/components/Server/ServerDetails.tsx
@@ -14,7 +14,7 @@ import {
 } from "@astrouxds/react";
 import { ServerData } from "../../services/ServerService";
 import { fetchDeviceMetrics } from "../../services/DeviceService";
-import CPULineChart from "./Charts/CPULineChart";
+import CPUPerCoreGrid from "./Charts/CPUPerCoreGrid";
 import GPULineChart from "./Charts/GPULineChart";
 import GPURamLineChart from "./Charts/GPURamLineChart";
 import RamLineChart from "./Charts/RamLineChart";
@@ -374,7 +374,7 @@ const ServerDetails: React.FC<Props> = ({ server, deviceId }) => {
           )}
           {view === "chart" && (
             <>
-              <CPULineChart server={server} />
+              <CPUPerCoreGrid server={server} />
               <GPULineChart server={server} />
               <GPURamLineChart server={server} />
               <RamLineChart server={server} />


### PR DESCRIPTION
## Summary
- show one MetricCard per CPU core in the new `CPUPerCoreGrid`
- display the new grid instead of `CPULineChart` in `ServerDetails`
