### PR TITLE
Add metric threshold CRUD routes and frontend management

### DIFF
--- a/CSI_API/src/index.ts
+++ b/CSI_API/src/index.ts
@@ -4,6 +4,7 @@ import "./db"; // ensure .env loads & db.ts runs
 import pdu from "./routes/PDUroutes/pduRoutes";
 import sites from "./routes/sites/sitesRoutes";
 import devices from "./routes/devices/deviceRoutes";
+import metricThresholds from "./routes/metricThresholds/metricThresholdRoutes";
 import mock from "./routes/mock/mockRoutes";
 import "./poller/pollDevices";
 
@@ -13,5 +14,6 @@ app.use("*", cors({ origin: "*" })); // Enable CORS for all routes
 app.route("/pdu", pdu);
 app.route("/sites", sites);
 app.route("/devices", devices);
+app.route("/metric-thresholds", metricThresholds);
 app.route("/mock", mock);
 export default app;

--- a/CSI_API/src/routes/devices/deviceRoutes.ts
+++ b/CSI_API/src/routes/devices/deviceRoutes.ts
@@ -2,7 +2,7 @@ import { Hono, Context } from "hono";
 import { eq } from "drizzle-orm";
 import "dotenv/config";
 import { db } from "../../db";
-import { devices } from "../../db/schema";
+import { devices, metrics } from "../../db/schema";
 import {
   CreateDeviceClientPayloadSchema,
   UpdateDeviceSchema,
@@ -350,6 +350,18 @@ app.get("/:id/metrics", async (c: Context) => {
     limit: 100,
   });
   return c.json(metrics);
+});
+
+app.get("/:id/metric-types", async (c: Context) => {
+  const deviceId = parseInt(c.req.param("id"));
+  if (isNaN(deviceId)) {
+    return c.json({ error: "Invalid device ID" }, 400);
+  }
+  const types = await db
+    .selectDistinct({ metricType: metrics.metricType })
+    .from(metrics)
+    .where(eq(metrics.deviceId, deviceId));
+  return c.json(types.map((t) => t.metricType));
 });
 app.get("/:id/sites", async (c: Context) => {
   const deviceId = parseInt(c.req.param("id"));

--- a/CSI_API/src/routes/metricThresholds/metricThresholdRoutes.ts
+++ b/CSI_API/src/routes/metricThresholds/metricThresholdRoutes.ts
@@ -1,0 +1,76 @@
+import { Hono, Context } from "hono";
+import { db } from "../../db";
+import { metricThresholds } from "../../db/schema";
+import { eq } from "drizzle-orm";
+import {
+  CreateMetricThresholdSchema,
+  UpdateMetricThresholdSchema,
+} from "./metricThresholdValidationSchemas";
+
+const app = new Hono();
+
+app.get("/", async (c: Context) => {
+  const all = await db.select().from(metricThresholds);
+  return c.json(all);
+});
+
+app.get("/device/:deviceId", async (c: Context) => {
+  const deviceId = parseInt(c.req.param("deviceId"));
+  if (isNaN(deviceId)) return c.json({ error: "Invalid device ID" }, 400);
+  const rows = await db.query.metricThresholds.findMany({
+    where: eq(metricThresholds.deviceId, deviceId),
+  });
+  return c.json(rows);
+});
+
+app.get("/:id", async (c: Context) => {
+  const id = parseInt(c.req.param("id"));
+  if (isNaN(id)) return c.json({ error: "Invalid id" }, 400);
+  const row = await db.query.metricThresholds.findFirst({
+    where: eq(metricThresholds.id, id),
+  });
+  if (!row) return c.json({ error: "Metric threshold not found" }, 404);
+  return c.json(row);
+});
+
+app.post("/", async (c: Context) => {
+  const body = await c.req.json();
+  const validation = CreateMetricThresholdSchema.safeParse(body);
+  if (!validation.success)
+    return c.json({ error: "Invalid input", details: validation.error.issues }, 400);
+  const inserted = await db.insert(metricThresholds).values(validation.data).returning();
+  return c.json(inserted[0], 201);
+});
+
+app.put("/:id", async (c: Context) => {
+  const id = parseInt(c.req.param("id"));
+  if (isNaN(id)) return c.json({ error: "Invalid id" }, 400);
+  const body = await c.req.json();
+  const validation = UpdateMetricThresholdSchema.safeParse(body);
+  if (!validation.success)
+    return c.json({ error: "Invalid input", details: validation.error.issues }, 400);
+  if (Object.keys(validation.data).length === 0)
+    return c.json({ error: "No fields to update" }, 400);
+  const updated = await db
+    .update(metricThresholds)
+    .set(validation.data)
+    .where(eq(metricThresholds.id, id))
+    .returning();
+  if (updated.length === 0)
+    return c.json({ error: "Metric threshold not found" }, 404);
+  return c.json(updated[0]);
+});
+
+app.delete("/:id", async (c: Context) => {
+  const id = parseInt(c.req.param("id"));
+  if (isNaN(id)) return c.json({ error: "Invalid id" }, 400);
+  const deleted = await db
+    .delete(metricThresholds)
+    .where(eq(metricThresholds.id, id))
+    .returning({ id: metricThresholds.id });
+  if (deleted.length === 0)
+    return c.json({ error: "Metric threshold not found" }, 404);
+  return c.json({ message: "Metric threshold deleted", id: deleted[0].id });
+});
+
+export default app;

--- a/CSI_API/src/routes/metricThresholds/metricThresholdValidationSchemas.ts
+++ b/CSI_API/src/routes/metricThresholds/metricThresholdValidationSchemas.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const CreateMetricThresholdSchema = z.object({
+  deviceId: z.number(),
+  metricType: z.string(),
+  warningThreshold: z.number().optional(),
+  criticalThreshold: z.number().optional(),
+  operator: z.enum(["greater_than", "less_than", "equals"]).optional(),
+  isActive: z.number().optional(),
+});
+
+export const UpdateMetricThresholdSchema = CreateMetricThresholdSchema.partial();

--- a/CSI_UI/src/components/Management/ManageDevices.tsx
+++ b/CSI_UI/src/components/Management/ManageDevices.tsx
@@ -16,6 +16,10 @@ import {
   updateDevice,
   deleteDevice,
   getRelatedSites,
+  fetchMetricTypes,
+  getThresholdsForDevice,
+  createMetricThreshold,
+  updateMetricThreshold,
   Device,
 } from "../../services";
 
@@ -28,10 +32,47 @@ const DeviceForm: React.FC<ManagementFormProps<Device>> = ({
   const [type, setType] = useState(item?.type || "");
   const [serviceUrl, setServiceUrl] = useState(item?.serviceUrl || "");
   const [siteId, setSiteId] = useState(item?.siteId ? String(item.siteId) : "");
+  const [metricTypes, setMetricTypes] = useState<string[]>([]);
+  const [thresholdInputs, setThresholdInputs] = useState<{
+    [metric: string]: { warning?: string; critical?: string; id?: number };
+  }>({});
+
+  useEffect(() => {
+    if (item) {
+      fetchMetricTypes(item.id).then(setMetricTypes);
+      getThresholdsForDevice(item.id).then((thr) => {
+        const map: { [m: string]: { warning?: string; critical?: string; id?: number } } = {};
+        thr.forEach((t) => {
+          map[t.metricType] = {
+            warning: t.warningThreshold?.toString() || "",
+            critical: t.criticalThreshold?.toString() || "",
+            id: t.id,
+          };
+        });
+        setThresholdInputs(map);
+      });
+    }
+  }, [item]);
 
   const handleSave = (e: React.FormEvent) => {
     e.preventDefault();
     onSubmit({ name, type, serviceUrl, siteId: parseInt(siteId, 10) });
+    if (item) {
+      metricTypes.forEach((m) => {
+        const vals = thresholdInputs[m] || {};
+        const payload = {
+          deviceId: item.id,
+          metricType: m,
+          warningThreshold: vals.warning ? parseFloat(vals.warning) : undefined,
+          criticalThreshold: vals.critical ? parseFloat(vals.critical) : undefined,
+        };
+        if (vals.id) {
+          updateMetricThreshold(vals.id, payload);
+        } else if (vals.warning || vals.critical) {
+          createMetricThreshold(payload);
+        }
+      });
+    }
   };
 
   return (
@@ -56,6 +97,31 @@ const DeviceForm: React.FC<ManagementFormProps<Device>> = ({
         value={siteId}
         onRuxinput={(e: any) => setSiteId(e.target.value)}
       />
+      {metricTypes.map((m) => (
+        <div key={m} style={{ marginBottom: "0.5rem" }}>
+          <span>{m}</span>
+          <RuxInput
+            label="Warning"
+            value={thresholdInputs[m]?.warning || ""}
+            onRuxinput={(e: any) =>
+              setThresholdInputs((prev) => ({
+                ...prev,
+                [m]: { ...prev[m], warning: e.target.value },
+              }))
+            }
+          />
+          <RuxInput
+            label="Critical"
+            value={thresholdInputs[m]?.critical || ""}
+            onRuxinput={(e: any) =>
+              setThresholdInputs((prev) => ({
+                ...prev,
+                [m]: { ...prev[m], critical: e.target.value },
+              }))
+            }
+          />
+        </div>
+      ))}
       <div className="form-actions">
         <RuxButton type="button" secondary onClick={onCancel}>
           Cancel

--- a/CSI_UI/src/services/DeviceService.ts
+++ b/CSI_UI/src/services/DeviceService.ts
@@ -68,6 +68,11 @@ export async function fetchDeviceMetrics(deviceId: number) {
   return resp.data;
 }
 
+export async function fetchMetricTypes(deviceId: number): Promise<string[]> {
+  const resp = await axios.get<string[]>(`${API_URL}/devices/${deviceId}/metric-types`);
+  return resp.data;
+}
+
 export async function deleteDevice(deviceId: number): Promise<void> {
   await axios.delete(`${API_URL}/devices/${deviceId}`);
 }

--- a/CSI_UI/src/services/MetricThresholdService.ts
+++ b/CSI_UI/src/services/MetricThresholdService.ts
@@ -1,0 +1,35 @@
+import axios from "axios";
+
+const API_URL = `${import.meta.env.VITE_BASE_URL}`;
+
+export interface MetricThreshold {
+  id: number;
+  deviceId: number;
+  metricType: string;
+  warningThreshold?: number | null;
+  criticalThreshold?: number | null;
+  operator?: string | null;
+  isActive?: number | null;
+}
+
+export type CreateMetricThresholdPayload = Omit<MetricThreshold, "id">;
+export type UpdateMetricThresholdPayload = Partial<CreateMetricThresholdPayload>;
+
+export async function getThresholdsForDevice(deviceId: number): Promise<MetricThreshold[]> {
+  const resp = await axios.get<MetricThreshold[]>(`${API_URL}/metric-thresholds/device/${deviceId}`);
+  return resp.data;
+}
+
+export async function createMetricThreshold(data: CreateMetricThresholdPayload): Promise<MetricThreshold> {
+  const resp = await axios.post<MetricThreshold>(`${API_URL}/metric-thresholds`, data);
+  return resp.data;
+}
+
+export async function updateMetricThreshold(id: number, data: UpdateMetricThresholdPayload): Promise<MetricThreshold> {
+  const resp = await axios.put<MetricThreshold>(`${API_URL}/metric-thresholds/${id}`, data);
+  return resp.data;
+}
+
+export async function deleteMetricThreshold(id: number): Promise<void> {
+  await axios.delete(`${API_URL}/metric-thresholds/${id}`);
+}

--- a/CSI_UI/src/services/index.ts
+++ b/CSI_UI/src/services/index.ts
@@ -3,3 +3,4 @@ export * from "./SiteService";
 export * from "./DeviceService";
 export * from "./ServerService";
 export * from "./UserService";
+export * from "./MetricThresholdService";


### PR DESCRIPTION
## Summary
- add metric threshold CRUD API and register route
- expose metric types via `/devices/:id/metric-types`
- update device management form to edit thresholds per metric
- add threshold service helpers
