### PR TITLE
Fix alerts table layout

### DIFF
--- a/CSI_UI/src/components/Alerts/AlertListItem.tsx
+++ b/CSI_UI/src/components/Alerts/AlertListItem.tsx
@@ -1,4 +1,13 @@
-import { RuxStatus, RuxButton, RuxIcon } from "@astrouxds/react";
+import {
+  RuxStatus,
+  RuxButton,
+  RuxIcon,
+  RuxTableRow,
+  RuxTableCell,
+  RuxTableHeader,
+  RuxTableHeaderRow,
+  RuxTableHeaderCell,
+} from "@astrouxds/react";
 import type { Alert } from "../../services/AlertService";
 import { formatDateTime } from "../../utils/FormatUtils";
 import "./Alerts.css";
@@ -45,22 +54,22 @@ const AlertListItem = ({
     return `${diffDays}d ago`;
   };
 
-  // Use grid layout for row, matching the modern panel
+  // Use RuxTableRow for consistent styling
   return (
-    <div
+    <RuxTableRow
       className={`alerts-table-row alert-row-${getSeverityStatus(
         alertItem.severity
       )}${alertItem.acknowledged ? " acknowledged" : ""}`}
       tabIndex={0}
       aria-label={`${alertItem.severity} alert: ${alertItem.message}`}
     >
-      <div className="table-cell-status">
+      <RuxTableCell className="table-cell-status">
         <div className="severity-indicator">
           <RuxStatus status={getSeverityStatus(alertItem.severity)} />
           <span className="severity-text">{alertItem.severity}</span>
         </div>
-      </div>
-      <div className="table-cell-content">
+      </RuxTableCell>
+      <RuxTableCell className="table-cell-content">
         <div className="alert-header">
           <div className="alert-location">
             <RuxIcon icon="place" size="small" />
@@ -90,8 +99,8 @@ const AlertListItem = ({
             </span>
           </div>
         )}
-      </div>
-      <div className="table-cell-actions">
+      </RuxTableCell>
+      <RuxTableCell className="table-cell-actions">
         <RuxButton
           className="acknowledge-btn"
           onClick={() => onAcknowledge && onAcknowledge(alertItem.id)}
@@ -101,18 +110,20 @@ const AlertListItem = ({
         >
           {alertItem.acknowledged ? "Unacknowledge" : "Acknowledge"}
         </RuxButton>
-      </div>
-    </div>
+      </RuxTableCell>
+    </RuxTableRow>
   );
 };
 
 // New AlertsListHeader component
 export const AlertsListHeader = () => (
-  <div className="alerts-table-header">
-    <div className="table-header-status">Severity</div>
-    <div className="table-header-content">Alert Details</div>
-    <div className="table-header-actions">Actions</div>
-  </div>
+  <RuxTableHeader className="alerts-table-header">
+    <RuxTableHeaderRow>
+      <RuxTableHeaderCell>Severity</RuxTableHeaderCell>
+      <RuxTableHeaderCell>Alert Details</RuxTableHeaderCell>
+      <RuxTableHeaderCell>Actions</RuxTableHeaderCell>
+    </RuxTableHeaderRow>
+  </RuxTableHeader>
 );
 
 export default AlertListItem;

--- a/CSI_UI/src/components/Alerts/Alerts.css
+++ b/CSI_UI/src/components/Alerts/Alerts.css
@@ -110,7 +110,7 @@
   flex: 1;
   overflow-y: auto;
   scroll-behavior: smooth;
-  max-height: 70vh;
+  max-height: 80vh;
 }
 
 /* REDESIGNED ALERT ROWS */

--- a/CSI_UI/src/components/Alerts/AlertsList.tsx
+++ b/CSI_UI/src/components/Alerts/AlertsList.tsx
@@ -1,6 +1,8 @@
-// Removed unused RuxTable imports for modern grid layout
-import AlertListItem from "./AlertListItem";
-import { AlertsListHeader } from "./AlertListItem";
+import AlertListItem, { AlertsListHeader } from "./AlertListItem";
+import {
+  RuxTable,
+  RuxTableBody,
+} from "@astrouxds/react";
 import type { Alert } from "../../services/AlertService";
 
 interface AlertsListProps {
@@ -25,9 +27,9 @@ const AlertsList = ({
   }
 
   return (
-    <div className="alerts-table">
+    <RuxTable className="alerts-table">
       <AlertsListHeader />
-      <div className="alerts-table-body">
+      <RuxTableBody className="alerts-table-body">
         {alerts.map((alert) => (
           <AlertListItem
             key={alert.id}
@@ -45,8 +47,8 @@ const AlertsList = ({
             }
           />
         ))}
-      </div>
-    </div>
+      </RuxTableBody>
+    </RuxTable>
   );
 };
 

--- a/CSI_UI/src/components/Alerts/AlertsPanel.css
+++ b/CSI_UI/src/components/Alerts/AlertsPanel.css
@@ -15,30 +15,19 @@
   min-height: 120px;
 }
 
+.alerts-panel::part(header) {
+  padding: 0;
+}
+
 .alerts-panel .rux-container__header {
   padding: 0 !important;
 }
 
-/* Remove all padding from rux-container__header, including shadow DOM and inline styles */
-:host(.alerts-panel) .rux-container__header,
-.alerts-panel .rux-container__header,
-.rux-container__header[part="header"],
-.rux-container__header {
-  padding: 0 !important;
-}
-
-/* Remove padding from slot content in header if present */
+/* Remove padding from slot content in header */
 .rux-container__header[part="header"] > *,
 .rux-container__header > * {
   margin: 0 !important;
   padding: 0 !important;
-}
-
-/* Remove padding from the slot itself if possible */
-.rux-container__header[part="header"] slot[name="header"] {
-  padding: 0 !important;
-  margin: 0 !important;
-  display: contents;
 }
 
 .alerts-list-wrapper {


### PR DESCRIPTION
## Summary
- use RuxTable components for alert list
- bump alert table height for 1080p screens
- clean up RuxContainer header padding
